### PR TITLE
Improve dataset pairing and warning handling

### DIFF
--- a/dataset_splitter.py
+++ b/dataset_splitter.py
@@ -2,44 +2,65 @@ import shutil
 from pathlib import Path
 from sklearn.model_selection import train_test_split
 
+
 def split_dataset(config):
     """將圖像和標註分割為訓練、驗證和測試集"""
-    split_config = config['train_test_split']
-    image_dir = Path(split_config['input']['image_dir'])
-    label_dir = Path(split_config['input']['label_dir'])
-    output_dir = Path(split_config['output']['output_dir'])
-    train_ratio = split_config['split_ratios']['train']
-    val_ratio = split_config['split_ratios']['val']
-    test_ratio = split_config['split_ratios']['test']
-    input_formats = split_config['input_formats']
-    label_format = split_config['label_format']
-    
-    images = sorted([str(p) for p in image_dir.glob("*") if p.suffix.lower() in input_formats])
-    labels = sorted([str(p) for p in label_dir.glob(f"*{label_format}")])
-    
-    print(f"圖像數量: {len(images)}, 標籤數量: {len(labels)}")
-    assert len(images) == len(labels), "圖片數量和標籤數量不一致"
-    
+    split_config = config["train_test_split"]
+    image_dir = Path(split_config["input"]["image_dir"])
+    label_dir = Path(split_config["input"]["label_dir"])
+    output_dir = Path(split_config["output"]["output_dir"])
+    train_ratio = split_config["split_ratios"]["train"]
+    val_ratio = split_config["split_ratios"]["val"]
+    test_ratio = split_config["split_ratios"]["test"]
+    input_formats = split_config["input_formats"]
+    label_format = split_config["label_format"]
+
+    image_dict = {
+        p.stem: p for p in image_dir.glob("*") if p.suffix.lower() in input_formats
+    }
+    label_dict = {
+        p.stem: p for p in label_dir.glob("*") if p.suffix.lower() == label_format
+    }
+
+    common_keys = image_dict.keys() & label_dict.keys()
+    missing_images = label_dict.keys() - image_dict.keys()
+    missing_labels = image_dict.keys() - label_dict.keys()
+
+    for key in sorted(missing_images):
+        print(f"警告: 找不到影像檔案 {label_dict[key]}")
+    for key in sorted(missing_labels):
+        print(f"警告: 找不到標籤檔案 {image_dict[key]}")
+
+    paired_images = [image_dict[k] for k in sorted(common_keys)]
+    paired_labels = [label_dict[k] for k in sorted(common_keys)]
+
     train_images, temp_images, train_labels, temp_labels = train_test_split(
-        images, labels, test_size=(val_ratio + test_ratio), random_state=42
+        paired_images,
+        paired_labels,
+        test_size=val_ratio + test_ratio,
+        random_state=42,
     )
-    
+
     val_images, test_images, val_labels, test_labels = train_test_split(
-        temp_images, temp_labels, test_size=test_ratio/(val_ratio + test_ratio), random_state=42
+        temp_images,
+        temp_labels,
+        test_size=test_ratio / (val_ratio + test_ratio),
+        random_state=42,
     )
-    
+
     output_dir.mkdir(parents=True, exist_ok=True)
     for split in ["train", "val", "test"]:
         (output_dir / split / "images").mkdir(parents=True, exist_ok=True)
         (output_dir / split / "labels").mkdir(parents=True, exist_ok=True)
-    
+
     def copy_files(images, labels, split):
         for img, lbl in zip(images, labels):
-            shutil.copy(img, output_dir / split / "images" / Path(img).name)
-            shutil.copy(lbl, output_dir / split / "labels" / Path(lbl).name)
-    
+            shutil.copy(img, output_dir / split / "images" / img.name)
+            shutil.copy(lbl, output_dir / split / "labels" / lbl.name)
+
     copy_files(train_images, train_labels, "train")
     copy_files(val_images, val_labels, "val")
     copy_files(test_images, test_labels, "test")
-    
+
     print("文件已成功分配並複製到訓練、驗證和測試目錄中")
+


### PR DESCRIPTION
## Summary
- Pair images and labels by file stem and warn about missing counterparts
- Split only matched pairs into train, validation, and test sets

## Testing
- `python -m py_compile dataset_splitter.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4075b2748326a690c62feaa18982