### PR TITLE
Expand image format support and refine label path handling

### DIFF
--- a/Picture_Annotator/Image_AutoAnnotator.py
+++ b/Picture_Annotator/Image_AutoAnnotator.py
@@ -185,8 +185,8 @@ class ImageAugmentor:
             self.logger.error(f"輸入圖片目錄不存在: {input_img_dir}")
             return
             
-        img_files = [f for f in os.listdir(input_img_dir) 
-                    if f.lower().endswith(('.jpg', '.jpeg', '.png'))]
+        img_files = [f for f in os.listdir(input_img_dir)
+                    if f.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff'))]
         
         if not img_files:
             self.logger.error("沒有找到圖片文件")

--- a/Picture_Annotator/YOLOAutoAnnotator.py
+++ b/Picture_Annotator/YOLOAutoAnnotator.py
@@ -159,7 +159,7 @@ class DataAugmentor:
         """處理單張圖片的增強"""
         try:
             img_path = Path(self.config['input']['image_dir']) / img_file
-            label_path = Path(self.config['input']['label_dir']) / img_file.replace('.jpg', '.txt').replace('.png', '.txt')
+            label_path = Path(self.config['input']['label_dir']) / (Path(img_file).stem + '.txt')
 
             # 讀取圖片
             image = cv2.imread(str(img_path))
@@ -239,8 +239,8 @@ class DataAugmentor:
             self.logger.error(f"輸入圖片目錄不存在: {input_img_dir}")
             return
             
-        img_files = [f for f in os.listdir(input_img_dir) 
-                    if f.lower().endswith(('.jpg', '.jpeg', '.png'))]
+        img_files = [f for f in os.listdir(input_img_dir)
+                    if f.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff'))]
         
         if not img_files:
             self.logger.error("沒有找到圖片文件")

--- a/image_augmentor.py
+++ b/image_augmentor.py
@@ -185,8 +185,8 @@ class ImageAugmentor:
             self.logger.error(f"輸入圖片目錄不存在: {input_img_dir}")
             return
             
-        img_files = [f for f in os.listdir(input_img_dir) 
-                    if f.lower().endswith(('.jpg', '.jpeg', '.png'))]
+        img_files = [f for f in os.listdir(input_img_dir)
+                    if f.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff'))]
         
         if not img_files:
             self.logger.error("沒有找到圖片文件")

--- a/yolo_data_augmentor.py
+++ b/yolo_data_augmentor.py
@@ -160,7 +160,7 @@ class DataAugmentor:
         """處理單張圖片的增強"""
         try:
             img_path = Path(self.config['input']['image_dir']) / img_file
-            label_path = Path(self.config['input']['label_dir']) / img_file.replace('.jpg', '.txt').replace('.png', '.txt')
+            label_path = Path(self.config['input']['label_dir']) / (Path(img_file).stem + '.txt')
 
             # 讀取圖片
             image = cv2.imread(str(img_path))
@@ -240,8 +240,8 @@ class DataAugmentor:
             self.logger.error(f"輸入圖片目錄不存在: {input_img_dir}")
             return
             
-        img_files = [f for f in os.listdir(input_img_dir) 
-                    if f.lower().endswith(('.jpg', '.jpeg', '.png'))]
+        img_files = [f for f in os.listdir(input_img_dir)
+                    if f.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff'))]
         
         if not img_files:
             self.logger.error("沒有找到圖片文件")


### PR DESCRIPTION
## Summary
- derive label paths using image stem for robust extension handling
- extend image file filters to include bmp and tiff variants across augmentor modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d407216fc83268ee605b77aaa4e84