### PR TITLE
Fix rotation angle limit for augmentations

### DIFF
--- a/Picture_Annotator/Image_AutoAnnotator.py
+++ b/Picture_Annotator/Image_AutoAnnotator.py
@@ -109,7 +109,8 @@ class ImageAugmentor:
         
         if ops_config.get('rotate'):
             angle = ops_config['rotate']['angle']
-            aug_list.append(A.Rotate(limit=angle if isinstance(angle, int) else angle[1], p=0.5))
+            limit = angle if isinstance(angle, (int, float)) else (angle[0], angle[1])
+            aug_list.append(A.Rotate(limit=limit, p=0.5))
         
         if ops_config.get('multiply'):
             multiply_range = ops_config['multiply']['range']

--- a/Picture_Annotator/YOLOAutoAnnotator.py
+++ b/Picture_Annotator/YOLOAutoAnnotator.py
@@ -116,7 +116,8 @@ class DataAugmentor:
         
         if ops_config.get('rotate'):
             angle = ops_config['rotate']['angle']
-            aug_list.append(A.Rotate(limit=angle if isinstance(angle, int) else angle[1], p=0.5))
+            limit = angle if isinstance(angle, (int, float)) else (angle[0], angle[1])
+            aug_list.append(A.Rotate(limit=limit, p=0.5))
         
         if ops_config.get('multiply'):
             multiply_range = ops_config['multiply']['range']

--- a/image_augmentor.py
+++ b/image_augmentor.py
@@ -99,7 +99,8 @@ class ImageAugmentor:
         
         if ops_config.get('rotate'):
             angle = ops_config['rotate']['angle']
-            aug_list.append(A.Rotate(limit=angle if isinstance(angle, int) else angle[1], p=0.5))
+            limit = angle if isinstance(angle, (int, float)) else (angle[0], angle[1])
+            aug_list.append(A.Rotate(limit=limit, p=0.5))
         
         if ops_config.get('multiply'):
             multiply_range = ops_config['multiply']['range']

--- a/yolo_data_augmentor.py
+++ b/yolo_data_augmentor.py
@@ -110,7 +110,8 @@ class DataAugmentor:
         
         if ops_config.get('rotate'):
             angle = ops_config['rotate']['angle']
-            aug_list.append(A.Rotate(limit=angle if isinstance(angle, int) else angle[1], p=0.5))
+            limit = angle if isinstance(angle, (int, float)) else (angle[0], angle[1])
+            aug_list.append(A.Rotate(limit=limit, p=0.5))
         
         if ops_config.get('multiply'):
             multiply_range = ops_config['multiply']['range']


### PR DESCRIPTION
## Summary
- handle scalar and tuple rotation angles correctly for albumentations

## Testing
- `python -m py_compile Picture_Annotator/Image_AutoAnnotator.py Picture_Annotator/YOLOAutoAnnotator.py image_augmentor.py yolo_data_augmentor.py`
- `python - <<'PY'
class DummyRotate:
    def __init__(self, limit, p):
        self.limit = limit
        self.p = p

def _create_dummy(angle):
    limit = angle if isinstance(angle, (int, float)) else (angle[0], angle[1])
    return DummyRotate(limit=limit, p=0.5)

rotate = _create_dummy((-30, 10))
print('Rotate limit:', rotate.limit)
PY`
- ❌ `python - <<'PY'
from yolo_data_augmentor import DataAugmentor
import albumentations as A

da = DataAugmentor()
da.config['augmentation']['operations']['rotate']['angle'] = (-30, 10)
da.augmentations = da._create_augmentations()
for t in da.augmentations.transforms:
    if isinstance(t, A.Rotate):
        print('Rotate limit:', t.limit)
PY` (missing cv2/albumentations)


------
https://chatgpt.com/codex/tasks/task_e_68a7c6fc66048326ab115d47e8655e3d