### PR TITLE
Refactor image format converter with logging and Path

### DIFF
--- a/image_format_converter.py
+++ b/image_format_converter.py
@@ -1,48 +1,54 @@
-import cv2
-import os
+import logging
 from pathlib import Path
+
+import cv2
+
+logger = logging.getLogger(__name__)
+
 
 def convert_format(format_config):
     """將指定資料夾中符合格式的圖像轉換為目標格式"""
-    # 直接使用 format_config，而不是 config['format_conversion']
     input_dir = Path(format_config['input_dir'])
     output_dir = Path(format_config['output_dir'])
     input_formats = format_config['input_formats']
     output_format = format_config['output_format']
     quality = format_config.get('quality', 95)
-    
-    # 檢查輸入資料夾是否存在
+    png_compression = format_config.get('png_compression', 3)
+
     if not input_dir.exists():
         raise FileNotFoundError(f"輸入資料夾 {input_dir} 不存在")
-    
-    # 確保輸出資料夾存在
-    os.makedirs(output_dir, exist_ok=True)
-    
-    # 遍歷輸入資料夾中的檔案
-    for filename in os.listdir(input_dir):
-        if any(filename.lower().endswith(fmt) for fmt in input_formats):
-            img_path = os.path.join(input_dir, filename)
-            img = cv2.imread(img_path)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for img_path in input_dir.iterdir():
+        if img_path.suffix.lower() in input_formats:
+            img = cv2.imread(str(img_path))
             if img is None:
-                print(f"讀取失敗: {img_path}")
+                logger.warning(f"讀取失敗: {img_path}")
                 continue
-            
-            output_filename = os.path.splitext(filename)[0] + output_format
-            output_path = os.path.join(output_dir, output_filename)
-            
+
+            output_filename = img_path.stem + output_format
+            output_path = output_dir / output_filename
+
             if output_format.lower() in ('.jpg', '.jpeg'):
-                cv2.imwrite(output_path, img, [int(cv2.IMWRITE_JPEG_QUALITY), quality])
+                cv2.imwrite(str(output_path), img, [int(cv2.IMWRITE_JPEG_QUALITY), quality])
+            elif output_format.lower() == '.png':
+                cv2.imwrite(str(output_path), img, [int(cv2.IMWRITE_PNG_COMPRESSION), png_compression])
             else:
-                cv2.imwrite(output_path, img)
-            
-            print(f"已轉換: {output_path}")
+                cv2.imwrite(str(output_path), img)
+
+            logger.info(f"已轉換: {output_path}")
+
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     config = {
         "input_dir": "./pcba_fail",
         "output_dir": "./pcba_fail_png",
         "input_formats": [".bmp"],
         "output_format": ".png",
-        "quality": 95
+        "quality": 95,
+        "png_compression": 3,
     }
     convert_format(config)
+


### PR DESCRIPTION
## Summary
- replace print statements with Python logging
- use Path operations instead of os.path
- ensure cv2.imwrite uses appropriate parameters for JPEG and PNG

## Testing
- `python -m py_compile image_format_converter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7d3dc01b483268e6b7b282f2bfa94