### PR TITLE
Fix padding parameter name in PadIfNeeded

### DIFF
--- a/Picture_Annotator/Image_AutoAnnotator.py
+++ b/Picture_Annotator/Image_AutoAnnotator.py
@@ -99,7 +99,7 @@ class ImageAugmentor:
             min_height=640,
             min_width=640,
             border_mode=cv2.BORDER_CONSTANT,
-            value=(0, 0, 0),  # 黑色填充
+            border_value=(0, 0, 0),  # 黑色填充
             p=1.0
         ))
 

--- a/Picture_Annotator/YOLOAutoAnnotator.py
+++ b/Picture_Annotator/YOLOAutoAnnotator.py
@@ -106,7 +106,7 @@ class DataAugmentor:
             min_height=640,
             min_width=640,
             border_mode=cv2.BORDER_CONSTANT,
-            value=(0, 0, 0),  # 黑色填充
+            border_value=(0, 0, 0),  # 黑色填充
             p=1.0
         ))
 

--- a/image_augmentor.py
+++ b/image_augmentor.py
@@ -136,7 +136,7 @@ class ImageAugmentor:
             min_height=640,
             min_width=640,
             border_mode=cv2.BORDER_CONSTANT,
-            value=(0, 0, 0),  # 黑色填充
+            border_value=(0, 0, 0),  # 黑色填充
             p=1.0
         ))
 

--- a/yolo_data_augmentor.py
+++ b/yolo_data_augmentor.py
@@ -149,7 +149,7 @@ class DataAugmentor:
             min_height=640,
             min_width=640,
             border_mode=cv2.BORDER_CONSTANT,
-            value=(128, 128, 128),  # 黑色填充
+            border_value=(128, 128, 128),  # 灰色填充
             p=1.0
         ))
         return A.Compose(


### PR DESCRIPTION
## Summary
- replace `value` with `border_value` in `A.PadIfNeeded`
- correct padding color comment in `yolo_data_augmentor.py`

## Testing
- `python -m py_compile yolo_data_augmentor.py image_augmentor.py Picture_Annotator/Image_AutoAnnotator.py Picture_Annotator/YOLOAutoAnnotator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7dd8caba08326a9047bfdf25b2fcb